### PR TITLE
Instance admin abilities

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -104,8 +104,8 @@ class ApplicationController < ActionController::Base
     return result.values
   end
 
-  def authorize_import
-    authorize! :import, Instance
+  def authorize_import(type)
+    authorize! ("import_" + type).to_sym, Instance
   end
 
   def authorize_restore

--- a/app/controllers/import/evaluation_templates_controller.rb
+++ b/app/controllers/import/evaluation_templates_controller.rb
@@ -2,7 +2,7 @@ require "csv"
 require "digilys/evaluation_template_importer"
 
 class Import::EvaluationTemplatesController < ApplicationController
-  before_filter :authorize_import
+  before_filter { authorize_import("evaluation_template") }
 
   def new
   end

--- a/app/controllers/import/instructions_controller.rb
+++ b/app/controllers/import/instructions_controller.rb
@@ -1,5 +1,5 @@
 class Import::InstructionsController < ApplicationController
-  before_filter :authorize_import
+  before_filter { authorize_import("instructions") }
 
   def new
   end

--- a/app/controllers/import/result_controller.rb
+++ b/app/controllers/import/result_controller.rb
@@ -2,7 +2,7 @@ require "csv"
 require "digilys/result_importer"
 
 class Import::ResultController < ApplicationController
-  before_filter :authorize_import
+  before_filter { authorize_import("result") }
 
   def new
     @suites = Suite.where(instance_id: current_user.active_instance_id, is_template: false).order(:name).all

--- a/app/controllers/import/student_data_controller.rb
+++ b/app/controllers/import/student_data_controller.rb
@@ -3,7 +3,7 @@ require "digilys/excel_converter"
 require "digilys/student_data_importer"
 
 class Import::StudentDataController < ApplicationController
-  before_filter :authorize_import
+  before_filter { authorize_import("student_data") }
 
   def new
   end

--- a/app/controllers/suites_controller.rb
+++ b/app/controllers/suites_controller.rb
@@ -193,7 +193,7 @@ class SuitesController < ApplicationController
   private
 
   def list(status)
-    if !current_user.has_role?(:admin)
+    if !current_user.has_role?(:admin) && !current_user.is_admin_of?(current_instance)
       # Needs to be unique in case a user have multiple roles for the same resource
       @suites = @suites.with_role([:suite_manager, :suite_member], current_user).uniq
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -138,6 +138,7 @@ class UsersController < ApplicationController
   end
 
   def instance_filter
+    @users = User if @users.nil?
     @users = @users.with_role(:member, current_instance)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -130,6 +130,7 @@ class UsersController < ApplicationController
   end
 
   def authorized_users
+    @users = User if @users.nil?
     @users = @users.with_role(:member, current_instance)
 
     @users = @users.where("users.id NOT IN (?)", User.with_any_role(:admin)) unless current_user.is_administrator?

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -41,7 +41,7 @@ class UsersController < ApplicationController
     end
 
     role_ids = params[:user].delete(:role_ids)
-    instance_ids = params[:user].delete(:instance_ids)
+    instance_ids = filter_instance_ids(params[:user].delete(:instance_ids))
 
     if @user.send(update_method, params[:user])
 
@@ -61,7 +61,7 @@ class UsersController < ApplicationController
   end
 
   def create
-    instance_ids = params[:user].delete(:instance_ids)
+    instance_ids = filter_instance_ids(params[:user].delete(:instance_ids))
     role_ids = params[:user].delete(:role_ids)
 
     @user = User.new(params[:user])
@@ -140,5 +140,14 @@ class UsersController < ApplicationController
   def instance_filter
     @users = User if @users.nil?
     @users = @users.with_role(:member, current_instance)
+  end
+
+  def filter_instance_ids(instance_ids)
+    instance_ids = [] if instance_ids.nil?
+    if !current_user.has_role?(:admin)
+      instance_ids = instance_ids & [current_user.active_instance.id.to_s]
+      # instance_ids.include?(current_user.active_instance.id.to_s) ? [current_user.active_instance.id] : []
+    end
+    return instance_ids
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -131,7 +131,9 @@ class UsersController < ApplicationController
 
   def authorized_users
     @users = @users.with_role(:member, current_instance)
-    @users = @users.where("users.id NOT IN (?)", User.with_any_role(:admin, :superuser)) unless current_user.is_administrator?
+
+    @users = @users.where("users.id NOT IN (?)", User.with_any_role(:admin)) unless current_user.is_administrator?
+    @users = @users.where("users.id NOT IN (?)", User.with_any_role(:superuser)) unless (current_user.is_administrator? || current_user.is_admin_of?(current_instance))
   end
 
   def instance_filter

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -99,6 +99,11 @@ class Ability
       end
       cannot :create, Suite
       cannot :destroy, Suite
+
+      can :control, Instance
+      can [ :view, :associate_users ], Instance do |inst|
+        user.is_admin_of?(inst)
+      end
     end
 
     can :list,    Suite

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -101,15 +101,15 @@ class Ability
       cannot :destroy, Suite
 
       can :control, Instance
-      can [ :view, :associate_users ], Instance do |inst|
-        user.is_admin_of?(inst)
-      end
-
       # Groups
       can [ :manage ], Group
       cannot [ :edit, :update, :destroy, :create_new ], Group
       cannot [ :select_students, :add_students, :remove_students ], Group
       cannot [ :select_users, :add_users, :remove_users ], Group
+    end
+
+    can [ :view, :associate_users ], Instance do |inst|
+      user.is_admin_of?(inst)
     end
 
     can :list,    Suite

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -83,13 +83,12 @@ class Ability
       can :import, Instance
       can :import_student_data, Instance
 
-      can :manage, User
-      can [ :view, :edit, :change ], User do |u|
-        u.instances.include?(active_instance)
+      can :create, User
+      can [ :manage, :view, :edit, :change ], User do |u|
+        u.instances.include?(active_instance) && !u.is_administrator?
       end
-      cannot [ :destroy ], User
       can [ :destroy ], User do |u|
-        !u.is_administrator?
+        u.instances.include?(active_instance) && !u.is_administrator?
       end
       cannot :change_instance, User
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -74,11 +74,14 @@ class Ability
 
       # Import
       can :import, Instance
+      can :import_instructions, Instance
+      can :import_student_data, Instance
+      can :import_evaluation_templates, Instance
+      can :import_results, Instance
     elsif is_instance_admin
       # Import
-      can :import, Instance do |instance|
-        user.is_admin_of?(instance)
-      end
+      can :import, Instance
+      can :import_student_data, Instance
 
       can :manage, User
       can [ :view, :edit, :change ], User do |u|

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -55,7 +55,7 @@ class Ability
       can :manage, Role
 
       # Groups
-      can    :manage, Group
+      can :manage, Group
 
       # Suites
       can :create,            Suite
@@ -104,6 +104,12 @@ class Ability
       can [ :view, :associate_users ], Instance do |inst|
         user.is_admin_of?(inst)
       end
+
+      # Groups
+      can [ :manage ], Group
+      cannot [ :edit, :update, :destroy, :create_new ], Group
+      cannot [ :select_students, :add_students, :remove_students ], Group
+      cannot [ :select_users, :add_users, :remove_users ], Group
     end
 
     can :list,    Suite

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -85,17 +85,18 @@ class Ability
         u.instances.include?(active_instance)
       end
       cannot [ :destroy ], User
+      can [ :destroy ], User do |u|
+        !u.is_administrator?
+      end
       cannot :change_instance, User
+
+      can :manage, Role
 
       can :manage, Suite do |suite|
         !suite.is_template? && user.is_admin_of?(suite.instance)
       end
       cannot :create, Suite
       cannot :destroy, Suite
-
-      # Groups
-      can    :manage, Group
-      cannot :destroy, Group
     end
 
     can :list,    Suite

--- a/app/models/instance.rb
+++ b/app/models/instance.rb
@@ -5,8 +5,6 @@ class Instance < ActiveRecord::Base
   has_many :groups
   has_and_belongs_to_many :users
 
-  belongs_to :admin, :class_name => "User", :foreign_key => "user_id"
-
   attr_accessible :name, :user_id
 
   validates :name, presence: true
@@ -19,5 +17,9 @@ class Instance < ActiveRecord::Base
     return Instance.order(:name).all if user.is_administrator?
 
     return Instance.where(id: user.active_instance).all
+  end
+
+  def admins
+    User.where(admin_instance_id: self.id).all
   end
 end

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -3,6 +3,13 @@ class Role < ActiveRecord::Base
   belongs_to :resource, polymorphic: true
 
   attr_accessible :name
-  
+
   scopify
+
+  def self.authorized_roles(current_user)
+    return Role.where(name: %w(admin superuser)).all if current_user.is_administrator?
+
+    return Role.where(name: "superuser").all if current_user.is_admin_of?(current_user.active_instance)
+    return []
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,7 @@ class User < ActiveRecord::Base
 
   has_many :settings, as: :customizer, dependent: :destroy
 
+  belongs_to :admin_instance, class_name: "Instance"
   belongs_to :active_instance, class_name: "Instance"
 
   # Setup accessible (or protected) attributes for your model
@@ -22,6 +23,7 @@ class User < ActiveRecord::Base
     :role_ids,
     :name,
     :active_instance_id,
+    :admin_instance_id,
     :instance_ids,
     :name_ordering
 
@@ -45,7 +47,6 @@ class User < ActiveRecord::Base
     end
   end
 
-
   def self.visible
     where(invisible: false)
   end
@@ -55,11 +56,7 @@ class User < ActiveRecord::Base
   end
 
   def is_admin_of?(instance)
-    return instance.admin == self unless instance.nil? || instance.admin.nil?
-  end
-
-  def is_admin?
-    return Instance.where(:user_id => self).any?
+    return self.admin_instance == instance unless self.admin_instance.nil?
   end
 
   def save_setting!(customizable, data)
@@ -75,7 +72,6 @@ class User < ActiveRecord::Base
     @instances ||= Instance.with_role(:member, self)
   end
 
-
   def name_ordering
     self.preferences ||= {}
     self.preferences["name_ordering"].try(:to_sym) || :first_name
@@ -89,7 +85,6 @@ class User < ActiveRecord::Base
       nil
     end
   end
-
 
   private
 

--- a/app/views/groups/_navigation.html.haml
+++ b/app/views/groups/_navigation.html.haml
@@ -23,8 +23,9 @@
 
     %li.secondaries
       %ul.nav.nav-tabs.nav-split
-        %li{class: active_if(active == :new)}
-          %a{href:new_group_path(copy_from: group.id)}= t(:".copy_action")
+        - if can? :create, Group
+          %li{class: active_if(active == :new)}
+            %a{href:new_group_path(copy_from: group.id)}= t(:".copy_action")
         - if can? :edit, group
           %li{class: active_if(active == :edit)}
             %a{href:edit_group_path(group)}= t(:".edit_action")
@@ -43,5 +44,6 @@
           %a{href:groups_path()}= t(:".index_action")
         %li{class: active_if(active == :closed)}
           %a{href:closed_groups_path()}= t(:".closed_action")
-        %li{class: active_if(active == :new)}
-          %a{href:new_group_path()}= t(:".new_action")
+        - if can? :create_new, Group
+          %li{class: active_if(active == :new)}
+            %a{href:new_group_path()}= t(:".new_action")

--- a/app/views/instances/_form.html.haml
+++ b/app/views/instances/_form.html.haml
@@ -2,8 +2,6 @@
 
   = f.input :name, required: true, input_html: { required: true, autofocus: true }
 
-  = f.input :admin, required: false, input_html: { required: false, autofocus: false }
-
   = f.actions do
     = f.action :submit, label: t(:".save_action"), button_html: { class: "btn btn-primary"}
     %a.btn{href:f.object.new_record? ? instances_path() : instance_path(f.object)}= t(:".cancel_action")

--- a/app/views/instances/_navigation.html.haml
+++ b/app/views/instances/_navigation.html.haml
@@ -9,8 +9,9 @@
     %ul.nav.nav-tabs.nav-split
       %li{class: active_if(active == :index)}
         %a{href:instances_path()}= t(:".index_action")
-      %li{class: active_if(active == :new)}
-        %a{href:new_instance_path()}= t(:".new_action")
+      - if can?(:create, Instance)
+        %li{class: active_if(active == :new)}
+          %a{href:new_instance_path()}= t(:".new_action")
       - if instance && can?(:show, instance)
         %li{class: active_if(active == :show)}
           %a{href:instance_path(instance)}= t(:".show_action")

--- a/app/views/instances/index.html.haml
+++ b/app/views/instances/index.html.haml
@@ -10,8 +10,9 @@
 
   %tbody
     - @instances.each do |instance|
-      %tr
-        %td.name= link_to(instance.name, instance)
-        %td.admins= instance.admins.collect{|u| u.name}.join(", ")
+      - if can? :view, instance
+        %tr
+          %td.name= link_to(instance.name, instance)
+          %td.admins= instance.admins.collect{|u| u.name}.join(", ")
 
 = paginate(@instances)

--- a/app/views/instances/index.html.haml
+++ b/app/views/instances/index.html.haml
@@ -6,10 +6,12 @@
   %thead
     %tr
       %th.name=   Instance.human_attribute_name(:name)
+      %th.name=   Instance.human_attribute_name(:admins)
 
   %tbody
     - @instances.each do |instance|
       %tr
         %td.name= link_to(instance.name, instance)
+        %td.admins= instance.admins.collect{|u| u.name}.join(", ")
 
 = paginate(@instances)

--- a/app/views/instances/show.html.haml
+++ b/app/views/instances/show.html.haml
@@ -11,14 +11,16 @@
         %tr.name
           %th= Instance.human_attribute_name(:name)
           %td= @instance.name
-- if @instance.admin
+- if @instance.admins.any?
   .row-fluid
     .span6
+      %h3= t(:".instance_admin")
       %table.table.table-bordered.details-table.instance-details-table
         %tbody
-          %tr.admin
-            %th= t(:".instance_admin")
-            %td= @instance.admin.name
+          - @instance.admins.each do |admin|
+            %tr.admin
+              %td= User.human_attribute_name(:name)
+              %td= admin.name
       %small= t(:".instance_admin_message")
 .row-fluid
   .span6

--- a/app/views/shared/_import_menu.html.haml
+++ b/app/views/shared/_import_menu.html.haml
@@ -2,7 +2,11 @@
   = t(:".title")
   %span.caret
 %ul.dropdown-menu
-  %li= link_to t(:".instructions"), new_import_instruction_path()
-  %li= link_to t(:".evaluation_templates"), new_import_evaluation_template_path()
-  %li= link_to t(:".student_data"), new_import_student_data_path()
-  %li= link_to t(:".results"), new_import_result_path()
+  - if can? :import_instructions, Instance
+    %li= link_to t(:".instructions"), new_import_instruction_path()
+  - if can? :import_evaluation_templates, Instance
+    %li= link_to t(:".evaluation_templates"), new_import_evaluation_template_path()
+  - if can? :import_student_data, Instance
+    %li= link_to t(:".student_data"), new_import_student_data_path()
+  - if can? :import_results, Instance
+    %li= link_to t(:".results"), new_import_result_path()

--- a/app/views/shared/_instance_indicator.html.haml
+++ b/app/views/shared/_instance_indicator.html.haml
@@ -5,7 +5,7 @@
   %ul.dropdown-menu
     %li.load-indicator.disabled
       %a(href="#")= t(:wait)
-    - if can?(:manage, Instance)
+    - if can?(:manage, Instance) || can?(:control, Instance)
       %li.divider
       %li
         = link_to t(:"instances.handle"), instances_path()

--- a/app/views/shared/_instance_indicator.html.haml
+++ b/app/views/shared/_instance_indicator.html.haml
@@ -5,7 +5,7 @@
   %ul.dropdown-menu
     %li.load-indicator.disabled
       %a(href="#")= t(:wait)
-    - if can?(:manage, Instance) || can?(:control, Instance)
+    - if can?(:manage, Instance) || !current_user.admin_instance.nil?
       %li.divider
       %li
         = link_to t(:"instances.handle"), instances_path()

--- a/app/views/shared/_students_menu.html.haml
+++ b/app/views/shared/_students_menu.html.haml
@@ -2,7 +2,7 @@
   = t(:".title")
   %span.caret
 %ul.dropdown-menu
-  - if can? :create, Suite
+  - if can? :manage, Student
     %li= link_to Student.model_name.human(count: 2), students_path()
-  - if can? :manage, Evaluation
+  - if can? :manage, Group
     %li= link_to Group.model_name.human(count: 2), groups_path()

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -34,15 +34,25 @@
               as: :check_boxes,
               collection: Instance.authorized_instances(current_user)
 
-      - if can? :manage, Role
+      - if can? :manage, Role or can? :manage, User
         = f.inputs t(:".roles_title") do
-          = f.input :roles,
-            as: :select,
-            include_blank: User.model_name.human,
-            collection: Role.where(name: %w(admin superuser)).collect { |r| [ t(:"roles.#{r.name}"), r.id ] },
-            input_html: { multiple: false }
-          .alert.alert-box.alert-info
-            = t(:".roles_explanation_html")
+          - if can? :manage, User
+            = f.input :admin_instance_id,
+              label: User.human_attribute_name(:admin_instance),
+              as: :select,
+              input_html: { multiple: false },
+              collection: current_user.is_administrator? ? Instance.all : [current_user.admin_instance]
+            .alert.alert-box.alert-info
+              = t(:".admin_instance_explanation_html")
+
+          - if can? :manage, Role
+            = f.input :roles,
+              as: :select,
+              include_blank: User.model_name.human,
+              collection: Role.authorized_roles(current_user).collect { |r| [ t(:"roles.#{r.name}"), r.id ] },
+              input_html: { multiple: false }
+            .alert.alert-box.alert-info
+              = t(:".roles_explanation_html")
 
       = f.actions do
         = f.action :submit, label: t(:".save_action"), button_html: { class: "btn btn-primary" }

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -13,6 +13,7 @@
         %th.name=   User.human_attribute_name(:name)
         %th.instance=   Instance.model_name.human(count: 1)
         %th.email=  Suite.human_attribute_name(:email)
+        %th.admin_of=  User.human_attribute_name(:admin_instance)
         %th.actions &nbsp;
     %tbody
       - @users.each do |user|
@@ -20,6 +21,7 @@
           %td.name=  user.name
           %td.name=  user.instances.map(&:name).join(",")
           %td.email= user.email
+          %td.admin_instance= user.admin_instance.name unless user.admin_instance.nil?
           %td.actions
             .btn-group
               - if can? :change, User

--- a/app/views/users/new.html.haml
+++ b/app/views/users/new.html.haml
@@ -25,12 +25,21 @@
     = f.input :password_confirmation, :required => true
     = f.input :registered_yubikey, as: :password, hint: Conf.yubikey.hint if Conf.yubikey
 
+    - if can? :manage, User
+      = f.input :admin_instance_id,
+        label: User.human_attribute_name(:admin_instance),
+        as: :select,
+        input_html: { multiple: false },
+        collection: current_user.is_administrator? ? Instance.all : [current_user.admin_instance]
+      .alert.alert-box.alert-info
+        = t(:".admin_instance_explanation_html")
+
     - if can? :manage, Role
       = f.inputs do
         = f.input :roles,
           as: :select,
           include_blank: User.model_name.human,
-          collection: Role.where(name: %w(admin superuser)).collect { |r| [ t(:"roles.#{r.name}"), r.id ] },
+          collection: Role.authorized_roles(current_user).collect { |r| [ t(:"roles.#{r.name}"), r.id ] },
           input_html: { multiple: false }
         .alert.alert-box.alert-info
           = t(:".roles_explanation_html")

--- a/config/locales/models.sv.yml
+++ b/config/locales/models.sv.yml
@@ -166,6 +166,7 @@ sv:
         registered_yubikey: YubiKey-lösenord
         instances: Instanser
         active_instance: Instans
+        admin_instance: Administrator för
         name_ordering: Sorteringsordning för elever
       instruction:
         title: Titel
@@ -177,6 +178,7 @@ sv:
         owner_id: Tillhör
       instance:
         name: Namn
+        admins: Administratörer
       series:
         name: Namn
         suite: Planering

--- a/config/locales/views.sv.yml
+++ b/config/locales/views.sv.yml
@@ -442,6 +442,17 @@ sv:
         <li><strong>Planerare</strong> kan skapa planeringar och lägga till Deltagare</li>
         <li><strong>Användare</strong> kan arbeta i de planeringar de är Deltagare</li>
       </ul>
+    admin_instance_explanation_html: |
+      <p>En administrator kan för sin instans:</p>
+      <ul>
+      <li>Skapa, ändra och radera användare</li>
+      <li>Importera elevlistor</li>
+      <li>Ändra och avsluta alla planeringar (inte radera)</li>
+      <li>Kopiera, avsluta och flytta upp klasser</li>
+      <li>Byta lösenord</li>
+      <li>Se historik för sin instans</li>
+      <li>Lägga till deltagare till alla planeringar samtidigt</li>
+      </ul>
 
   visualizations:
     navigation:

--- a/db/migrate/20160403111046_user_instance_admin.rb
+++ b/db/migrate/20160403111046_user_instance_admin.rb
@@ -1,0 +1,10 @@
+class UserInstanceAdmin < ActiveRecord::Migration
+  def up
+    remove_column :instances, :user_id
+    add_column :users, :admin_instance_id, :integer
+  end
+  def down
+    add_column :instances, :user_id, :integer
+    remove_column :users, :admin_instance_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20140626082134) do
+ActiveRecord::Schema.define(:version => 20160403111046) do
 
   create_table "activities", :force => true do |t|
     t.integer  "suite_id"
@@ -25,6 +25,7 @@ ActiveRecord::Schema.define(:version => 20140626082134) do
     t.datetime "updated_at",  :null => false
     t.date     "end_date"
     t.date     "start_date"
+    t.datetime "deleted_at"
   end
 
   create_table "activities_groups", :id => false, :force => true do |t|
@@ -55,6 +56,7 @@ ActiveRecord::Schema.define(:version => 20140626082134) do
     t.integer  "suite_id"
     t.datetime "created_at",                     :null => false
     t.datetime "updated_at",                     :null => false
+    t.datetime "deleted_at"
   end
 
   create_table "color_tables_evaluations", :id => false, :force => true do |t|
@@ -84,6 +86,8 @@ ActiveRecord::Schema.define(:version => 20140626082134) do
     t.integer  "series_id"
     t.boolean  "is_series_current",                 :default => false
     t.boolean  "imported",                          :default => false
+    t.integer  "position",                          :default => 0
+    t.datetime "deleted_at"
   end
 
   add_index "evaluations", ["status"], :name => "index_evaluations_on_status"
@@ -132,6 +136,13 @@ ActiveRecord::Schema.define(:version => 20140626082134) do
     t.datetime "updated_at", :null => false
   end
 
+  create_table "instances_users", :id => false, :force => true do |t|
+    t.integer "instance_id"
+    t.integer "user_id"
+  end
+
+  add_index "instances_users", ["instance_id", "user_id"], :name => "index_instances_users_on_ids"
+
   create_table "instructions", :force => true do |t|
     t.string   "title"
     t.string   "for_page"
@@ -152,6 +163,7 @@ ActiveRecord::Schema.define(:version => 20140626082134) do
     t.datetime "created_at",                    :null => false
     t.datetime "updated_at",                    :null => false
     t.text     "agenda"
+    t.datetime "deleted_at"
   end
 
   create_table "participants", :force => true do |t|
@@ -160,6 +172,7 @@ ActiveRecord::Schema.define(:version => 20140626082134) do
     t.datetime "created_at", :null => false
     t.datetime "updated_at", :null => false
     t.integer  "group_id"
+    t.datetime "deleted_at"
   end
 
   create_table "rails_admin_histories", :force => true do |t|
@@ -184,6 +197,7 @@ ActiveRecord::Schema.define(:version => 20140626082134) do
     t.string   "color"
     t.integer  "stanine"
     t.boolean  "absent",        :default => false
+    t.datetime "deleted_at"
   end
 
   create_table "roles", :force => true do |t|
@@ -192,6 +206,7 @@ ActiveRecord::Schema.define(:version => 20140626082134) do
     t.string   "resource_type"
     t.datetime "created_at",    :null => false
     t.datetime "updated_at",    :null => false
+    t.datetime "deleted_at"
   end
 
   add_index "roles", ["name", "resource_type", "resource_id"], :name => "index_roles_on_name_and_resource_type_and_resource_id"
@@ -202,6 +217,7 @@ ActiveRecord::Schema.define(:version => 20140626082134) do
     t.string   "name"
     t.datetime "created_at", :null => false
     t.datetime "updated_at", :null => false
+    t.datetime "deleted_at"
   end
 
   create_table "settings", :force => true do |t|
@@ -235,6 +251,7 @@ ActiveRecord::Schema.define(:version => 20140626082134) do
     t.string   "student_data",        :limit => 1024
     t.integer  "instance_id"
     t.string   "status",                              :default => "open"
+    t.datetime "deleted_at"
   end
 
   create_table "table_states", :force => true do |t|
@@ -244,6 +261,7 @@ ActiveRecord::Schema.define(:version => 20140626082134) do
     t.string   "base_type"
     t.datetime "created_at", :null => false
     t.datetime "updated_at", :null => false
+    t.datetime "deleted_at"
   end
 
   create_table "taggings", :force => true do |t|
@@ -254,6 +272,7 @@ ActiveRecord::Schema.define(:version => 20140626082134) do
     t.string   "tagger_type"
     t.string   "context",       :limit => 128
     t.datetime "created_at"
+    t.datetime "deleted_at"
   end
 
   add_index "taggings", ["tag_id"], :name => "index_taggings_on_tag_id"
@@ -282,6 +301,7 @@ ActiveRecord::Schema.define(:version => 20140626082134) do
     t.integer  "active_instance_id"
     t.boolean  "invisible",              :default => false
     t.text     "preferences",            :default => "{}"
+    t.integer  "admin_instance_id"
   end
 
   add_index "users", ["email"], :name => "index_users_on_email", :unique => true

--- a/spec/controllers/import/evaluation_templates_controller_spec.rb
+++ b/spec/controllers/import/evaluation_templates_controller_spec.rb
@@ -10,6 +10,17 @@ describe Import::EvaluationTemplatesController, versioning: !ENV["debug_versioni
       get :new
       expect(response).to be_success
     end
+    context "as instance admin" do
+      login_user(:user)
+      before(:each) do
+        logged_in_user.admin_instance = logged_in_user.active_instance
+        logged_in_user.save
+      end
+      it "returns 401" do
+        get :new
+        expect(response.status).to be 401
+      end
+    end
   end
 
   describe "POST #confirm" do
@@ -36,6 +47,19 @@ describe Import::EvaluationTemplatesController, versioning: !ENV["debug_versioni
       expect(flash[:error]).not_to be_empty
       expect(response).to redirect_to(new_import_evaluation_template_url())
     end
+    context "as instance admin" do
+      login_user(:user)
+      before(:each) do
+        logged_in_user.admin_instance = logged_in_user.active_instance
+        logged_in_user.save
+      end
+      it "returns 401" do
+        Timecop.freeze(timestamp) do
+          post :confirm, csv_file: uploaded_file
+        end
+        expect(response.status).to be 401
+      end
+    end
   end
 
   describe "POST #create" do
@@ -53,6 +77,17 @@ describe Import::EvaluationTemplatesController, versioning: !ENV["debug_versioni
         post :create, filename: File.basename(temp_file)
         expect(response).to redirect_to(template_evaluations_url())
         expect(Evaluation.count).to eq 1
+      end
+      context "as instance admin" do
+        login_user(:user)
+        before(:each) do
+          logged_in_user.admin_instance = logged_in_user.active_instance
+          logged_in_user.save
+        end
+        it "returns 401" do
+          post :create, filename: File.basename(temp_file)
+          expect(response.status).to be 401
+        end
       end
     end
     context "without an uploaded file" do

--- a/spec/controllers/import/instructions_controller_spec.rb
+++ b/spec/controllers/import/instructions_controller_spec.rb
@@ -10,6 +10,19 @@ describe Import::InstructionsController, versioning: !ENV["debug_versioning"].bl
       get :new
       expect(response).to be_success
     end
+
+    context "as instance admin" do
+      login_user(:user)
+      before(:each) do
+        logged_in_user.admin_instance = logged_in_user.active_instance
+        logged_in_user.save
+      end
+      it "returns 401" do
+        get :new
+        expect(response.status).to be 401
+      end
+    end
+
   end
   describe "POST #confirm" do
     let(:first_object)   { { "foo" => 1 } }
@@ -21,6 +34,17 @@ describe Import::InstructionsController, versioning: !ENV["debug_versioning"].bl
       expect(response).to be_success
       expect(assigns(:uploaded_instructions)).to include(first_object)
       expect(assigns(:uploaded_instructions)).to include(second_object)
+    end
+    context "as instance admin" do
+      login_user(:user)
+      before(:each) do
+        logged_in_user.admin_instance = logged_in_user.active_instance
+        logged_in_user.save
+      end
+      it "returns 401" do
+        post :confirm, export_file: export_file_io
+        expect(response.status).to be 401
+      end
     end
   end
   describe "POST #create" do
@@ -64,6 +88,17 @@ describe Import::InstructionsController, versioning: !ENV["debug_versioning"].bl
 
       expect(existing.for_page).to eq new_instruction1[:for_page]
       expect(existing.title).to    eq new_instruction1[:title]
+    end
+    context "as instance admin" do
+      login_user(:user)
+      before(:each) do
+        logged_in_user.admin_instance = logged_in_user.active_instance
+        logged_in_user.save
+      end
+      it "returns 401" do
+        post :create, instructions: { 0 => new_instruction1, 1 => new_instruction2 }
+        expect(response.status).to be 401
+      end
     end
   end
 end

--- a/spec/controllers/import/result_controller_spec.rb
+++ b/spec/controllers/import/result_controller_spec.rb
@@ -83,8 +83,8 @@ describe Import::ResultController, versioning: !ENV["debug_versioning"].blank? d
       context "as admin of instance" do
         login_user(:user)
         before(:each) do
-          logged_in_user.active_instance.admin = logged_in_user
-          logged_in_user.active_instance.save
+          logged_in_user.admin_instance = logged_in_user.active_instance
+          logged_in_user.save
         end
         it "redirects to root url" do
           post :create, filename: File.basename(temp_file), evaluation: evaluation

--- a/spec/controllers/import/student_data_controller_spec.rb
+++ b/spec/controllers/import/student_data_controller_spec.rb
@@ -10,6 +10,17 @@ describe Import::StudentDataController, versioning: !ENV["debug_versioning"].bla
       get :new
       expect(response).to be_success
     end
+    context "as instance admin" do
+      login_user(:user)
+      before(:each) do
+        logged_in_user.admin_instance = logged_in_user.active_instance
+        logged_in_user.save
+      end
+      it "is successful" do
+        get :new
+        expect(response).to be_successful
+      end
+    end
   end
 
   describe "POST #confirm" do
@@ -34,11 +45,32 @@ describe Import::StudentDataController, versioning: !ENV["debug_versioning"].bla
       expect(assigns(:importer)).to be_a(Digilys::StudentDataImporter)
       expect(File.exist?(expected_file)).to be_true
     end
-    
+
     it "handles errors" do
       post :confirm, excel_file: nil
       expect(response).to redirect_to(new_import_student_data_url())
       expect(flash[:error]).not_to be_empty
+    end
+
+    context "as instance admin" do
+      login_user(:user)
+      before(:each) do
+        logged_in_user.admin_instance = logged_in_user.active_instance
+        logged_in_user.save
+      end
+      it "is successful" do
+        Timecop.freeze(timestamp) do
+          post :confirm,
+            excel_file: fixture_file_upload(
+              "/student_data.xlsx",
+              "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+            )
+        end
+
+        expect(assigns(:filename)).to eq filename
+        expect(assigns(:importer)).to be_a(Digilys::StudentDataImporter)
+        expect(File.exist?(expected_file)).to be_true
+      end
     end
   end
 
@@ -59,6 +91,21 @@ describe Import::StudentDataController, versioning: !ENV["debug_versioning"].bla
         expect(response).to redirect_to(students_url())
         expect(Student.count).to eq 1
         expect(Group.count).to   eq 2
+      end
+      context "as instance admin" do
+        login_user(:user)
+        before(:each) do
+          logged_in_user.admin_instance = logged_in_user.active_instance
+          logged_in_user.save
+        end
+        it "imports data from the file" do
+          expect(Student.count).to eq 0
+          expect(Group.count).to   eq 0
+          post :create, filename: File.basename(temp_file)
+          expect(response).to redirect_to(students_url())
+          expect(Student.count).to eq 1
+          expect(Group.count).to   eq 2
+        end
       end
     end
     context "without an uploaded file" do

--- a/spec/controllers/instances_controller_spec.rb
+++ b/spec/controllers/instances_controller_spec.rb
@@ -65,14 +65,6 @@ describe InstancesController, versioning: !ENV["debug_versioning"].blank? do
       post :create, instance: invalid_parameters_for(:instance)
       expect(response).to render_template("new")
     end
-    context "with admin" do
-      let(:admin) { create(:user) }
-      it "add roles to admin" do
-        params = { name: "instans", user_id: admin.id }
-        post :create, instance: params
-        expect(admin.has_role?(:member, Instance.where(name: "instans").first)).to be_true
-      end
-    end
   end
 
   describe "GET #edit" do
@@ -91,49 +83,6 @@ describe InstancesController, versioning: !ENV["debug_versioning"].blank? do
     it "renders the edit view when validation fails" do
       put :update, id: instance.id, instance: invalid_parameters_for(:instance)
       expect(response).to render_template("edit")
-    end
-    context "with admin" do
-      let(:prev_admin) { create(:user) }
-      let(:new_admin) { create(:user) }
-      let(:instance) { create(:instance, admin: prev_admin) }
-      let!(:suite_1) { create(:suite, instance: instance) }
-      let!(:suite_2) { create(:suite, instance: instance) }
-      let(:instance_user) { create(:user, instances: [instance]) }
-      it "add roles to new admin" do
-        params = { name: "instans", user_id: new_admin.id }
-        put :update, id: instance.id, instance: params
-        expect(new_admin.has_role?(:member, Instance.where(name: "instans").first)).to be_true
-      end
-      it "removes roles for previous admin" do
-        params = { name: "instans", user_id: new_admin.id }
-        put :update, id: instance.id, instance: params
-        expect(prev_admin.has_role?(:member, Instance.where(name: "instans").first)).to be_false
-      end
-      it "add suite roles to new admin" do
-        params = { name: "instans", user_id: new_admin.id }
-        put :update, id: instance.id, instance: params
-        expect(new_admin.has_role?(:suite_member, suite_1)).to be_true
-        expect(new_admin.has_role?(:suite_member, suite_1)).to be_true
-      end
-      it "removes suite roles for previous admin" do
-        params = { name: "instans", user_id: new_admin.id }
-        put :update, id: instance.id, instance: params
-        expect(prev_admin.has_role?(:suite_member, suite_1)).to be_false
-        expect(prev_admin.has_role?(:suite_member, suite_1)).to be_false
-      end
-      it "removes roles unless user is member of instance" do
-        params = { name: "instans", user_id: instance_user.id }
-        put :update, id: instance.id, instance: params
-        expect(instance_user.has_role?(:member, Instance.where(name: "instans").first)).to be_true
-        expect(instance_user.has_role?(:suite_member, suite_1)).to be_true
-        expect(instance_user.has_role?(:suite_member, suite_1)).to be_true
-
-        params = { name: "instans", user_id: new_admin.id }
-        put :update, id: instance.id, instance: params
-        expect(instance_user.has_role?(:member, Instance.where(name: "instans").first)).to be_true
-        expect(instance_user.has_role?(:suite_member, suite_1)).to be_true
-        expect(instance_user.has_role?(:suite_member, suite_1)).to be_true
-      end
     end
   end
   describe "add user" do

--- a/spec/controllers/suites_controller_spec.rb
+++ b/spec/controllers/suites_controller_spec.rb
@@ -184,6 +184,24 @@ describe SuitesController, versioning: !ENV["debug_versioning"].blank? do
       get :log, id: other_suite.id
       expect(response.status).to be 404
     end
+    context "as instance admin" do
+      login_user(:user)
+      let(:other_instance)      { create(:instance) }
+      let(:suite)         { create(:suite, instance: logged_in_user.active_instance) }
+      let(:other_suite)   { create(:suite, instance: other_instance) }
+      before(:each) do
+        logged_in_user.admin_instance = logged_in_user.active_instance
+        logged_in_user.save
+      end
+      it "is successful" do
+        get :log, id: suite.id
+        expect(response).to be_success
+      end
+      it "returns 401 is user is not admin of instance" do
+        get :log, id: other_suite.id
+        expect(response.status).to be 401
+      end
+    end
   end
 
   describe "GET #new" do

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -60,13 +60,13 @@ describe UsersController, versioning: !ENV["debug_versioning"].blank? do
       before(:each) do
         users.first.add_role(:admin)
         users.second.add_role(:superuser)
-        logged_in_user.active_instance.admin = logged_in_user
-        logged_in_user.active_instance.save
+        logged_in_user.admin_instance = logged_in_user.active_instance
+        logged_in_user.save
       end
-      it "does not list admins or superusers" do
+      it "does not list admins" do
         get :index
         expect(response).to be_successful
-        expect(assigns(:users)).to match_array([ users.third, logged_in_user ])
+        expect(assigns(:users)).to match_array([ users.second, users.third, logged_in_user ])
       end
     end
   end
@@ -164,8 +164,8 @@ describe UsersController, versioning: !ENV["debug_versioning"].blank? do
         let!(:suite_1) { create(:suite, instance: instances.first) }
         let!(:suite_2) { create(:suite, instance: instances.second) }
         before(:each) do
-          instances.first.admin = admin
-          instances.first.save
+          admin.admin_instance = instances.first
+          admin.save
           user.instances = [instances.first]
           user.save
         end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -140,6 +140,10 @@ describe Ability do
       it              { should_not be_able_to(:select_users, Group) }
       it              { should_not be_able_to(:add_users, Group) }
       it              { should_not be_able_to(:remove_users, Group) }
+
+      # Log
+      it              { should be_able_to(:log, suite) }
+      it              { should_not be_able_to(:log, other_suite) }
     end
   end
 

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -51,15 +51,19 @@ describe Ability do
     end
 
     context "Instance admin" do
-      let!(:instance)  { create(:instance) }
-      let!(:user)      { create(:user, admin_instance: instance) }
-      let!(:admin)      { create(:admin) }
-      let!(:suite)     { create(:suite, instance: instance) }
-      let!(:template_suite)     { create(:suite, instance: instance, is_template: true) }
-      let!(:evaluation){ create(:suite_evaluation, suite: suite) }
+      let!(:instance)             { create(:instance) }
+      let!(:other_instance)       { create(:instance) }
+      let!(:user)                 { create(:user, admin_instance: instance) }
+      let!(:other_user)           { create(:user) }
+      let!(:instance_member)      { create(:user) }
+      let!(:admin)                { create(:admin) }
+      let!(:suite)                { create(:suite, instance: instance) }
+      let!(:template_suite)       { create(:suite, instance: instance, is_template: true) }
+      let!(:evaluation)           { create(:suite_evaluation, suite: suite) }
       before(:each) do
         user.active_instance = instance
-        user.save
+        instance_member.add_role(:member, instance)
+        admin.add_role(:member, instance)
       end
       subject(:ability) { Ability.new(user) }
       it              { should be_able_to(:import, Instance) }
@@ -67,17 +71,27 @@ describe Ability do
       it              { should_not be_able_to(:import_instructions, Instance) }
       it              { should_not be_able_to(:import_evaluation_templates, Instance) }
       it              { should_not be_able_to(:import_results, Instance) }
-      it              { should be_able_to(:manage, User) }
-      it              { should be_able_to(:view, User) }
-      it              { should be_able_to(:manage, User) }
-      it              { should be_able_to(:create, User) }
-      it              { should be_able_to(:change, User) }
-      it              { should be_able_to(:view, User) }
-      it              { should be_able_to(:edit, User) }
-      it              { should be_able_to(:destroy, User) }
+
+      # User
+      it              { should be_able_to(:manage, instance_member) }
+      it              { should be_able_to(:view, instance_member) }
+      it              { should be_able_to(:edit, instance_member) }
+      it              { should be_able_to(:change, instance_member) }
+      it              { should be_able_to(:destroy, instance_member) }
+
+      it              { should_not be_able_to(:manage, other_user) }
+      it              { should_not be_able_to(:view, other_user) }
+      it              { should_not be_able_to(:edit, other_user) }
+      it              { should_not be_able_to(:change, other_user) }
+      it              { should_not be_able_to(:destroy, other_user) }
+
+      it              { should_not be_able_to(:manage, admin) }
+      it              { should_not be_able_to(:view, admin) }
+      it              { should_not be_able_to(:edit, admin) }
+      it              { should_not be_able_to(:change, admin) }
       it              { should_not be_able_to(:destroy, admin) }
+
       it              { should be_able_to(:manage, Role) }
-      it              { should be_able_to(:edit, user) }
       it              { should be_able_to(:manage, suite) }
       it              { should_not be_able_to(:destroy, suite) }
       it              { should_not be_able_to(:manage, template_suite) }

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -47,6 +47,7 @@ describe Ability do
 
       it { should_not be_able_to(:select, not_member_of) }
       it { should     be_able_to(:select, member_of) }
+      it { should_not be_able_to(:import, Instance) }
     end
 
     context "Instance admin" do
@@ -62,6 +63,10 @@ describe Ability do
       end
       subject(:ability) { Ability.new(user) }
       it              { should be_able_to(:import, Instance) }
+      it              { should be_able_to(:import_student_data, Instance) }
+      it              { should_not be_able_to(:import_instructions, Instance) }
+      it              { should_not be_able_to(:import_evaluation_templates, Instance) }
+      it              { should_not be_able_to(:import_results, Instance) }
       it              { should be_able_to(:manage, User) }
       it              { should be_able_to(:view, User) }
       it              { should be_able_to(:manage, User) }
@@ -85,6 +90,10 @@ describe Ability do
     it         { should be_able_to(:manage, :all) }
     it         { should be_able_to(:import, :all) }
     it         { should be_able_to(:import, Instance) }
+    it         { should be_able_to(:import_student_data, Instance) }
+    it         { should be_able_to(:import_instructions, Instance) }
+    it         { should be_able_to(:import_evaluation_templates, Instance) }
+    it         { should be_able_to(:import_results, Instance) }
     it         { should be_able_to(:manage, Role) }
   end
 

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -122,6 +122,24 @@ describe Ability do
 
       it              { should_not be_able_to(:view, other_instance) }
       it              { should_not be_able_to(:associate_users, other_instance) }
+
+      # Group
+      it              { should be_able_to(:manage, Group) }
+      it              { should be_able_to(:view, Group) }
+      it              { should be_able_to(:copy, Group) }
+      it              { should be_able_to(:create, Group) }
+      it              { should be_able_to(:move_students, Group) }
+
+      it              { should_not be_able_to(:edit, Group) }
+      it              { should_not be_able_to(:update, Group) }
+      it              { should_not be_able_to(:create_new, Group) }
+      it              { should_not be_able_to(:destroy, Group) }
+      it              { should_not be_able_to(:select_students, Group) }
+      it              { should_not be_able_to(:add_students, Group) }
+      it              { should_not be_able_to(:remove_students, Group) }
+      it              { should_not be_able_to(:select_users, Group) }
+      it              { should_not be_able_to(:add_users, Group) }
+      it              { should_not be_able_to(:remove_users, Group) }
     end
   end
 

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -48,6 +48,7 @@ describe Ability do
       it { should_not be_able_to(:select, not_member_of) }
       it { should     be_able_to(:select, member_of) }
       it { should_not be_able_to(:import, Instance) }
+      it { should_not be_able_to(:control, Instance) }
     end
 
     context "Instance admin" do
@@ -112,6 +113,15 @@ describe Ability do
       it              { should_not be_able_to(:destroy, template_suite) }
       it              { should_not be_able_to(:manage, template_suite) }
       it              { should_not be_able_to(:destroy, template_suite) }
+
+      # Instance
+      it              { should be_able_to(:control, Instance) }
+
+      it              { should be_able_to(:view, instance) }
+      it              { should be_able_to(:associate_users, instance) }
+
+      it              { should_not be_able_to(:view, other_instance) }
+      it              { should_not be_able_to(:associate_users, other_instance) }
     end
   end
 

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -58,6 +58,7 @@ describe Ability do
       let!(:instance_member)      { create(:user) }
       let!(:admin)                { create(:admin) }
       let!(:suite)                { create(:suite, instance: instance) }
+      let!(:other_suite)          { create(:suite, instance: other_instance) }
       let!(:template_suite)       { create(:suite, instance: instance, is_template: true) }
       let!(:evaluation)           { create(:suite_evaluation, suite: suite) }
       before(:each) do
@@ -91,9 +92,24 @@ describe Ability do
       it              { should_not be_able_to(:change, admin) }
       it              { should_not be_able_to(:destroy, admin) }
 
+      # Role
       it              { should be_able_to(:manage, Role) }
+
+      # Suite
+      it              { should_not be_able_to(:create, Suite) }
+
       it              { should be_able_to(:manage, suite) }
+      it              { should be_able_to(:view, suite) }
+      it              { should be_able_to(:edit, suite) }
+      it              { should be_able_to(:change, suite) }
       it              { should_not be_able_to(:destroy, suite) }
+
+      it              { should_not be_able_to(:destroy, other_suite) }
+      it              { should_not be_able_to(:view, other_suite) }
+      it              { should_not be_able_to(:edit, other_suite) }
+      it              { should_not be_able_to(:change, other_suite) }
+
+      it              { should_not be_able_to(:destroy, template_suite) }
       it              { should_not be_able_to(:manage, template_suite) }
       it              { should_not be_able_to(:destroy, template_suite) }
     end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -115,8 +115,6 @@ describe Ability do
       it              { should_not be_able_to(:destroy, template_suite) }
 
       # Instance
-      it              { should be_able_to(:control, Instance) }
-
       it              { should be_able_to(:view, instance) }
       it              { should be_able_to(:associate_users, instance) }
 

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -50,8 +50,9 @@ describe Ability do
     end
 
     context "Instance admin" do
-      let!(:user)      { create(:user) }
-      let!(:instance)  { create(:instance, admin: user) }
+      let!(:instance)  { create(:instance) }
+      let!(:user)      { create(:user, admin_instance: instance) }
+      let!(:admin)      { create(:admin) }
       let!(:suite)     { create(:suite, instance: instance) }
       let!(:template_suite)     { create(:suite, instance: instance, is_template: true) }
       let!(:evaluation){ create(:suite_evaluation, suite: suite) }
@@ -68,8 +69,9 @@ describe Ability do
       it              { should be_able_to(:change, User) }
       it              { should be_able_to(:view, User) }
       it              { should be_able_to(:edit, User) }
-      it              { should_not be_able_to(:destroy, User) }
-      it              { should_not be_able_to(:manage, Role) }
+      it              { should be_able_to(:destroy, User) }
+      it              { should_not be_able_to(:destroy, admin) }
+      it              { should be_able_to(:manage, Role) }
       it              { should be_able_to(:edit, user) }
       it              { should be_able_to(:manage, suite) }
       it              { should_not be_able_to(:destroy, suite) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -128,9 +128,9 @@ describe User do
   end
 
   context "instance admin" do
-    let(:user)  { create(:user) }
-    let(:instance_admin) { create(:user) }
-    let(:instance)       { create(:instance, admin: instance_admin) }
+    let(:instance)       { create(:instance) }
+    let(:user)           { create(:user) }
+    let(:instance_admin) { create(:user, admin_instance: instance) }
 
     it { expect(instance_admin.is_admin_of?(instance)).to be_true }
     it { expect(user.is_admin_of?(instance)).to be_false }

--- a/spec/views/users/edit.html.haml_spec.rb
+++ b/spec/views/users/edit.html.haml_spec.rb
@@ -31,8 +31,7 @@ describe "users/edit" do
     let(:current_user) { create(:user) }
     let(:is_admin)     { false }
     before(:each) do
-      current_user.active_instance.admin = current_user
-      instances.first.admin = current_user
+      current_user.admin_instance = current_user.active_instance
     end
     it                 { should     have_selector("h1", text: user.name) }
     it                 { should_not have_selector("input[name='user[current_password]']") }

--- a/spec/views/users/index.html.haml_spec.rb
+++ b/spec/views/users/index.html.haml_spec.rb
@@ -25,8 +25,8 @@ describe "users/index" do
   login_user(:user)
   let(:users) { create_list(:user, 2) }
   before(:each) do
-    logged_in_user.active_instance.admin = logged_in_user
-    logged_in_user.active_instance.save
+    logged_in_user.admin_instance = logged_in_user.active_instance
+    logged_in_user.save
 
     users << logged_in_user
     assign(:users, Kaminari.paginate_array(users).page(1).per(10))
@@ -35,7 +35,7 @@ describe "users/index" do
   context "instance admin" do
     subject { rendered }
     it      { should have_selector(".users-table tbody tr", count: 3) }
-    it      { should have_selector(".users-table tbody a.btn-mini", count: 3) }
-    it      { should have_selector(".users-table tbody a.btn-danger", count: 0) }
+    it      { should have_selector(".users-table tbody a.btn-mini", count: 5) }
+    it      { should have_selector(".users-table tbody a.btn-danger", count: 2) }
   end
 end

--- a/spec/views/users/new.html.haml_spec.rb
+++ b/spec/views/users/new.html.haml_spec.rb
@@ -25,8 +25,8 @@ describe "users/new" do
   context "for instance admin" do
     login_user(:user)
     before(:each) do
-      current_user.active_instance.admin = current_user
-      current_user.active_instance.save!
+      current_user.admin_instance = current_user.active_instance
+      current_user.save!
     end
     it                 { should     have_selector("input[id='user_name']") }
     it                 { should     have_selector("input[id='user_email']") }


### PR DESCRIPTION
An administrator for an instance can
- create, edit, delete users
- import student data
- change and finish (not delete) suites
- copy and finish and move students of groups
- view history for its instance
- add users to all suites for an instance