### PR TITLE
rename superuser to planner

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,6 +39,8 @@ GEM
       multi_json (~> 1.0)
     acts-as-taggable-on (2.4.1)
       rails (>= 3, < 5)
+    acts_as_list (0.7.2)
+      activerecord (>= 3.0)
     arel (3.0.3)
     bcrypt-ruby (3.0.1)
     bootstrap-datepicker-rails (1.0.0.5)
@@ -174,6 +176,8 @@ GEM
       activesupport (= 3.2.17)
       bundler (~> 1.0)
       railties (= 3.2.17)
+    rails-trash (2.0.0)
+      rails (>= 3.0.0)
     railties (3.2.17)
       actionpack (= 3.2.17)
       activesupport (= 3.2.17)
@@ -261,6 +265,7 @@ PLATFORMS
 
 DEPENDENCIES
   acts-as-taggable-on (~> 2.4.1)
+  acts_as_list
   bootstrap-datepicker-rails (~> 1.0.0.5)
   bootstrap-sass (~> 2.3.1.0)
   cancan (~> 1.6.9)
@@ -286,6 +291,7 @@ DEPENDENCIES
   pry (~> 0.9.12)
   pry-remote (~> 0.1.7)
   rails (= 3.2.17)
+  rails-trash
   ransack (~> 0.7.2)
   rolify (~> 3.2.0)
   roo (~> 1.13.2)
@@ -301,3 +307,6 @@ DEPENDENCIES
   uglifier (>= 1.0.3)
   yajl-ruby (~> 1.1.0)
   yubikey_database_authenticatable!
+
+BUNDLED WITH
+   1.11.2

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -131,7 +131,7 @@ class UsersController < ApplicationController
     @users = @users.with_role(:member, current_instance)
 
     @users = @users.where("users.id NOT IN (?)", User.with_any_role(:admin)) unless current_user.is_administrator?
-    @users = @users.where("users.id NOT IN (?)", User.with_any_role(:superuser)) unless (current_user.is_administrator? || current_user.is_admin_of?(current_instance))
+    @users = @users.where("users.id NOT IN (?)", User.with_any_role(:planner)) unless (current_user.is_administrator? || current_user.is_admin_of?(current_instance))
   end
 
   def instance_filter

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -47,7 +47,7 @@ class Ability
       can :restore, :all
       can :change_instance, User
       can :manage, Role
-    elsif user.has_role?(:superuser)
+    elsif user.has_role?(:planner)
       # Students
       can    :manage, Student
       cannot :destroy, Student

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -7,9 +7,9 @@ class Role < ActiveRecord::Base
   scopify
 
   def self.authorized_roles(current_user)
-    return Role.where(name: %w(admin superuser)).all if current_user.is_administrator?
+    return Role.where(name: %w(admin planner)).all if current_user.is_administrator?
 
-    return Role.where(name: "superuser").all if current_user.is_admin_of?(current_user.active_instance)
+    return Role.where(name: "planner").all if current_user.is_admin_of?(current_user.active_instance)
     return []
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -52,7 +52,7 @@ class User < ActiveRecord::Base
   end
 
   def is_administrator?
-    return has_any_role?(:admin, :superuser)
+    return has_any_role?(:admin, :planner)
   end
 
   def is_admin_of?(instance)

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -266,7 +266,7 @@ sv:
 
   roles:
     admin: Administratör
-    superuser: Planerare
+    planner: Planerare
 
   eula_confirmation: Jag har läst och förstått
 

--- a/db/migrate/20160410092350_rename_superuser.rb
+++ b/db/migrate/20160410092350_rename_superuser.rb
@@ -1,0 +1,19 @@
+class RenameSuperuser < ActiveRecord::Migration
+  def up
+    Role.all.each do |role|
+      if role.name == "superuser"
+        role.name = "planner"
+        role.save!
+      end
+    end
+  end
+
+  def down
+    Role.all.each do |role|
+      if role.name == "planner"
+        role.name = "superuser"
+        role.save!
+      end
+    end
+  end
+end

--- a/db/seeds/basic.rb
+++ b/db/seeds/basic.rb
@@ -3,10 +3,10 @@
 # Run app:factory:students first
 #
 # 3 users:
-# - 1 superuser
+# - 1 planner
 # - 1 reader (regular user)
 # - 1 editor (regular user)
-# 
+#
 # 1 evaluation template
 #
 # 2 generic evaluations, booleans
@@ -19,17 +19,17 @@
 
 instance = Instance.order("id asc").first
 
-puts "Superuser"
+puts "planner"
 user = User.new do |u|
-  u.name                  = "Superuser"
-  u.email                 = "superuser@example.com"
+  u.name                  = "planner"
+  u.email                 = "planner@example.com"
   u.password              = "testtest"
   u.password_confirmation = "testtest"
   u.active_instance       = instance
 end
 
 user.save!
-user.add_role :superuser
+user.add_role :planner
 
 puts "Reader"
 user = User.new do |u|

--- a/lib/tasks/bootstrap.rake
+++ b/lib/tasks/bootstrap.rake
@@ -15,7 +15,7 @@ namespace :app do
       puts "Creating roles"
 
       puts Role.where(name: "admin").first_or_create.name
-      puts Role.where(name: "superuser").first_or_create.name
+      puts Role.where(name: "planner").first_or_create.name
     end
   end
 end

--- a/spec/controllers/import/evaluation_templates_controller_spec.rb
+++ b/spec/controllers/import/evaluation_templates_controller_spec.rb
@@ -10,8 +10,8 @@ describe Import::EvaluationTemplatesController, versioning: !ENV["debug_versioni
       get :new
       expect(response).to be_success
     end
-    context "as superuser" do
-      login_user(:superuser)
+    context "as planner" do
+      login_user(:planner)
       it "returns 401" do
         get :new
         expect(response.status).to be 401
@@ -43,8 +43,8 @@ describe Import::EvaluationTemplatesController, versioning: !ENV["debug_versioni
       expect(flash[:error]).not_to be_empty
       expect(response).to redirect_to(new_import_evaluation_template_url())
     end
-    context "as superuser" do
-      login_user(:superuser)
+    context "as planner" do
+      login_user(:planner)
       it "returns 401" do
         post :confirm
         expect(response.status).to be 401
@@ -139,8 +139,8 @@ describe Import::EvaluationTemplatesController, versioning: !ENV["debug_versioni
         expect(Evaluation.count).to eq 2
       end
     end
-    context "as superuser" do
-      login_user(:superuser)
+    context "as planner" do
+      login_user(:planner)
       it "returns 401" do
         post :create
         expect(response.status).to be 401

--- a/spec/controllers/import/instructions_controller_spec.rb
+++ b/spec/controllers/import/instructions_controller_spec.rb
@@ -10,8 +10,8 @@ describe Import::InstructionsController, versioning: !ENV["debug_versioning"].bl
       get :new
       expect(response).to be_success
     end
-    context "as superuser" do
-      login_user(:superuser)
+    context "as planner" do
+      login_user(:planner)
       it "returns 401" do
         get :new
         expect(response.status).to be 401
@@ -30,8 +30,8 @@ describe Import::InstructionsController, versioning: !ENV["debug_versioning"].bl
       expect(assigns(:uploaded_instructions)).to include(first_object)
       expect(assigns(:uploaded_instructions)).to include(second_object)
     end
-    context "as superuser" do
-      login_user(:superuser)
+    context "as planner" do
+      login_user(:planner)
       it "returns 401" do
         post :confirm
         expect(response.status).to be 401
@@ -81,8 +81,8 @@ describe Import::InstructionsController, versioning: !ENV["debug_versioning"].bl
       expect(existing.for_page).to eq new_instruction1[:for_page]
       expect(existing.title).to    eq new_instruction1[:title]
     end
-    context "as superuser" do
-      login_user(:superuser)
+    context "as planner" do
+      login_user(:planner)
       it "returns 401" do
         post :create
         expect(response.status).to be 401

--- a/spec/controllers/import/result_controller_spec.rb
+++ b/spec/controllers/import/result_controller_spec.rb
@@ -21,8 +21,8 @@ describe Import::ResultController, versioning: !ENV["debug_versioning"].blank? d
       expect(response).to be_success
     end
 
-    context "as superuser" do
-      login_user(:superuser)
+    context "as planner" do
+      login_user(:planner)
       it "returns 401" do
         get :new
         expect(response.status).to be 401
@@ -60,8 +60,8 @@ describe Import::ResultController, versioning: !ENV["debug_versioning"].blank? d
       expect(flash[:error]).not_to be_empty
       expect(response).to redirect_to(new_import_result_path())
     end
-    context "as superuser" do
-      login_user(:superuser)
+    context "as planner" do
+      login_user(:planner)
       it "returns 401" do
         post :confirm
         expect(response.status).to be 401
@@ -141,8 +141,8 @@ describe Import::ResultController, versioning: !ENV["debug_versioning"].blank? d
         expect(response).to redirect_to(suite_path(suite))
       end
     end
-    context "as superuser" do
-      login_user(:superuser)
+    context "as planner" do
+      login_user(:planner)
       it "returns 401" do
         post :create
         expect(response.status).to be 401

--- a/spec/controllers/import/student_data_controller_spec.rb
+++ b/spec/controllers/import/student_data_controller_spec.rb
@@ -10,8 +10,8 @@ describe Import::StudentDataController, versioning: !ENV["debug_versioning"].bla
       get :new
       expect(response).to be_success
     end
-    context "as superuser" do
-      login_user(:superuser)
+    context "as planner" do
+      login_user(:planner)
       it "returns 401" do
         get :new
         expect(response.status).to be 401
@@ -47,8 +47,8 @@ describe Import::StudentDataController, versioning: !ENV["debug_versioning"].bla
       expect(response).to redirect_to(new_import_student_data_url())
       expect(flash[:error]).not_to be_empty
     end
-    context "as superuser" do
-      login_user(:superuser)
+    context "as planner" do
+      login_user(:planner)
       it "returns 401" do
         post :confirm
         expect(response.status).to be 401
@@ -114,8 +114,8 @@ describe Import::StudentDataController, versioning: !ENV["debug_versioning"].bla
         expect(response).to redirect_to(new_import_student_data_url())
       end
     end
-    context "as superuser" do
-      login_user(:superuser)
+    context "as planner" do
+      login_user(:planner)
       it "returns 401" do
         post :create
         expect(response.status).to be 401

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -61,7 +61,8 @@ describe UsersController, versioning: !ENV["debug_versioning"].blank? do
       let!(:users)           { create_list(:user, 3, active_instance: logged_in_user.active_instance) }
       before(:each) do
         users.first.add_role(:admin)
-        users.second.add_role(:superuser)
+        users.second.add_role(:planner)
+        users.second.save
         logged_in_user.admin_instance = logged_in_user.active_instance
         logged_in_user.save
       end
@@ -167,26 +168,26 @@ describe UsersController, versioning: !ENV["debug_versioning"].blank? do
       expect(response).to render_template("edit")
     end
     it "changes roles when applicable" do
-      user.add_role :superuser
+      user.add_role :planner
       user.save
 
       put :update, id: user.id, user: { role_ids: [Role.find_by_name("admin").id] }
 
-      expect(user.has_role?(:superuser)).to be_false
+      expect(user.has_role?(:planner)).to be_false
       expect(user.has_role?(:admin)).to     be_true
     end
     it "only touches global roles, not instance roles" do
-      user.add_role :superuser
+      user.add_role :planner
       user.add_role :resource, Instance
       user.add_role :instance, Instance.first
 
       put :update, id: user.id, user: { role_ids: [Role.find_by_name("admin").id] }
 
-      expect(user).not_to have_role(:superuser)
+      expect(user).not_to have_role(:planner)
       expect(user).to     have_role(:admin)
       expect(user).to     have_role(:resource, Instance)
       expect(user).to     have_role(:instance, Instance.first)
-      expect(Role.where(name: "superuser").exists?).to be_true
+      expect(Role.where(name: "planner").exists?).to be_true
     end
 
     context "instances" do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -18,8 +18,8 @@ FactoryGirl.define do
     factory :admin do
       after(:create) { |user| user.add_role :admin }
     end
-    factory :superuser do
-      after(:create) { |user| user.add_role :superuser }
+    factory :planner do
+      after(:create) { |user| user.add_role :planner }
     end
     factory(:invalid_user) do
       name nil

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -157,8 +157,8 @@ describe Ability do
     it         { should be_able_to(:manage, Role) }
   end
 
-  context "Superuser" do
-    let(:user)     { create(:superuser) }
+  context "Planner" do
+    let(:user)     { create(:planner) }
 
     it { should     be_able_to(:manage,  Student) }
     it { should_not be_able_to(:destroy, Student) }

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -176,7 +176,7 @@ describe Activity do
   end
 
   describe "#where_suite_member" do
-    let(:user)                    { create(:superuser) }
+    let(:user)                    { create(:planner) }
     let(:contributed_suite)       { create(:suite) }
     let(:managed_suite)           { create(:suite) }
     let(:not_allowed_suite)       { create(:suite) }

--- a/spec/models/evaluation_spec.rb
+++ b/spec/models/evaluation_spec.rb
@@ -1239,7 +1239,7 @@ describe Evaluation do
   end
 
   describe "#where_suite_member" do
-    let(:user)                     { create(:superuser) }
+    let(:user)                     { create(:planner) }
     let(:contributed_suite)        { create(:suite) }
     let(:managed_suite)            { create(:suite) }
     let(:not_allowed_suite)        { create(:suite) }

--- a/spec/models/meeting_spec.rb
+++ b/spec/models/meeting_spec.rb
@@ -101,7 +101,7 @@ describe Meeting do
   end
 
   describe "#where_suite_member" do
-    let(:user)                  { create(:superuser) }
+    let(:user)                  { create(:planner) }
     let(:contributed_suite)     { create(:suite) }
     let(:managed_suite)         { create(:suite) }
     let(:not_allowed_suite)     { create(:suite) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -10,8 +10,8 @@ describe User do
       subject { build(:admin) }
       it { should be_valid }
     end
-    context "superuser" do
-      subject { build(:superuser) }
+    context "planner" do
+      subject { build(:planner) }
       it { should be_valid }
     end
     context "invalid" do


### PR DESCRIPTION
Superuser is a bad name since it makes it hard to distinguish between "admins" and "superusers". Superusers are in fact "planners", so it's weird to use the term superuser for them.