### PR TITLE
default order is deleted_at desc according to #27

### DIFF
--- a/app/controllers/trash_controller.rb
+++ b/app/controllers/trash_controller.rb
@@ -3,10 +3,10 @@ class TrashController < ApplicationController
   before_filter :authorize_restore
 
   def index
-    @suites = Suite.deleted.all
+    @suites = Suite.deleted.order("deleted_at desc").all
     @evaluations = Evaluation.deleted.
       joins("LEFT OUTER JOIN suites ON evaluations.suite_id = suites.id").
       where("evaluations.suite_id IS NULL OR suites.deleted_at IS NULL").
-      order("suites.deleted_at").all
+      order("suites.deleted_at desc").all
   end
 end


### PR DESCRIPTION
Should close #27 

Both Suites and Evaluations should be sorted by default to descending order (last deletion at top) in the Trashcan as according to user request.